### PR TITLE
Refactor: User 엔티티 롬복 어노테이션 분리 및 생성일 자동화, @Data 제거

### DIFF
--- a/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
@@ -1,17 +1,12 @@
 package com.balgoorm.balgoorm_backend.user.model.entity;
-
-import com.balgoorm.balgoorm_backend.board.model.entity.Board;
 import jakarta.persistence.*;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
-@Data
-@Builder
+
+@Getter
 @Entity
 @NoArgsConstructor
 @Table(name = "USERS")
@@ -21,7 +16,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String userId;
 
     @Column(nullable = false)
@@ -30,34 +25,33 @@ public class User {
     @Column(nullable = false)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(updatable = false)
     private LocalDateTime createDate;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-//    private List<Board> boards = new ArrayList<>();
+    // 생성일 자동 세팅
+    @PrePersist
+    public void prePersist() {
+        this.createDate = LocalDateTime.now();
+    }
 
-
-//    @ManyToOne
-//    @JoinColumn(name = "CHAT_ROOM_ID", nullable = false)
-//    private ChatRoom chatRoom;
-
-    // All args constructor for Builder pattern
     @Builder
-    public User(Long id, String userId, String userPassword, String nickname, String email, LocalDateTime createDate, UserRole role) {
+    public User(Long id, String userId, String userPassword, String nickname, String email, UserRole role) {
         this.id = id;
         this.userId = userId;
         this.userPassword = userPassword;
         this.nickname = nickname;
         this.email = email;
-        this.createDate = createDate;
         this.role = role;
-//        this.boards = boards != null ? boards : new ArrayList<>();
-//        this.chatRoom = chatRoom;
     }
+
+    // 연관관계는 주석 처리(필요 시 활성화)
+    // @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    // private List<Board> boards = new ArrayList<>();
 }


### PR DESCRIPTION
## 주요 변경 내용

- User 엔티티에서 @Data 대신 @Getter, @NoArgsConstructor, @Builder로 어노테이션 분리
- createDate 필드를 @PrePersist로 자동 세팅하도록 변경 (생성자/빌더에서는 제거)
- email, userId 필드에 unique 옵션 추가로 데이터 무결성 강화
- Setter, AllArgsConstructor 등 불필요한 코드 제거
- 연관관계(Board, ChatRoom 등)는 주석 처리하여 필요시만 활성화
- 엔티티 구조에 주석 추가, 가독성 및 유지보수성 향상

## 기대 효과

- 불필요한 Setter/Equals/ToString 생성 방지로 보안 및 성능 향상
- 생성일 자동화로 실수 방지 및 코드 단순화
- 실무 표준에 맞는 엔티티 구조로 유지보수성과 확장성 증가

---
