### PR TITLE
Refactor: User 엔티티에서 수정 필요한 필드에만 Setter 직접 추가

### DIFF
--- a/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
@@ -3,9 +3,11 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.LocalDateTime;
 
-
+@Setter
 @Getter
 @Entity
 @NoArgsConstructor
@@ -19,9 +21,11 @@ public class User {
     @Column(nullable = false, unique = true)
     private String userId;
 
+    @Setter
     @Column(nullable = false)
     private String userPassword;
 
+    @Setter
     @Column(nullable = false)
     private String nickname;
 


### PR DESCRIPTION
## 주요 변경 내용

- User 엔티티의 닉네임(nickname), 비밀번호(userPassword) 필드에 Setter 메서드를 추가하였습니다.
- 롬복 @Setter 어노테이션을 필드별로 적용하거나, 직접 Setter 메서드를 작성하여 불필요한 전체 Setter 생성을 방지했습니다.
- 수정 가능한 필드만 Setter를 제공하여 엔티티 불변성 및 코드 안정성을 강화하였습니다.

## 기대 효과

- 서비스 계층에서 닉네임 및 비밀번호 변경 시, 보다 명확하게 필드 값을 수정할 수 있습니다.
- 엔티티 전체 Setter 사용에 따른 보안/유지보수 리스크를 줄였습니다.

