### PR TITLE
Refactor: Board 관련 엔티티 생성일 자동화 및 불필요한 빌더 파라미터 제거

### DIFF
--- a/src/main/java/com/balgoorm/balgoorm_backend/board/config/TempConfig.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/config/TempConfig.java
@@ -1,4 +1,0 @@
-package com.balgoorm.balgoorm_backend.board.config;
-
-public class TempConfig {
-}

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Board.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Board.java
@@ -2,52 +2,65 @@ package com.balgoorm.balgoorm_backend.board.model.entity;
 
 import com.balgoorm.balgoorm_backend.user.model.entity.User;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
+import lombok.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Data
+@Getter
 @NoArgsConstructor
 public class Board {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long boardId;
+
+    @Setter
     private String boardTitle;
+    @Setter
     private String boardContent;
+
     private LocalDateTime boardCreateDate;
+
     private int likesCount;
     private int viewCount;
 
-    @ManyToOne
+    // 작성자(유저)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false)
     private User user;
 
+    // 이미지 리스트
+    @Setter
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @OrderBy("id asc")
-    private List<BoardImage> boardImages;
+    private List<BoardImage> boardImages = new ArrayList<>();
 
+    // 댓글 리스트
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @OrderBy("commentCreateDate asc")
     private List<Comment> comments = new ArrayList<>();
 
+    // 조회수 기록(뷰)
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<View> views = new ArrayList<>();
 
     @Builder
-    public Board(String boardTitle, String boardContent, LocalDateTime boardCreateDate, User user) {
+    public Board(String boardTitle, String boardContent, User user) {
         this.boardTitle = boardTitle;
         this.boardContent = boardContent;
-        this.boardCreateDate = boardCreateDate != null ? boardCreateDate : LocalDateTime.now();
         this.user = user;
         this.likesCount = 0;
         this.viewCount = 0;
     }
 
+    @PrePersist
+    protected void onCreate() {
+        this.boardCreateDate = LocalDateTime.now();
+    }
+
+    // 좋아요/조회수 증가/감소 메서드
     public void incrementLikes() {
         this.likesCount++;
     }
@@ -60,3 +73,4 @@ public class Board {
         this.viewCount++;
     }
 }
+

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/BoardImage.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/BoardImage.java
@@ -2,11 +2,11 @@ package com.balgoorm.balgoorm_backend.board.model.entity;
 
 import jakarta.persistence.*;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Data
+@Getter
 @NoArgsConstructor
 @Table(name = "boardImage")
 public class BoardImage {

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Comment.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Comment.java
@@ -3,25 +3,28 @@ package com.balgoorm.balgoorm_backend.board.model.entity;
 import com.balgoorm.balgoorm_backend.user.model.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Data
+@Getter
 @NoArgsConstructor
 public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
+
+    @Setter
     private String commentContent;
     private LocalDateTime commentCreateDate;
     private int likesCount;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false)
     private User user;
 
@@ -30,26 +33,23 @@ public class Comment {
     private Board board;
 
     @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-    private List<Likes> likes = new ArrayList<>(); // 좋아요 리스트
+    private List<Likes> likes = new ArrayList<>();
 
     @Builder
-    public Comment(String commentContent, LocalDateTime commentCreateDate, User user, Board board) {
+    public Comment(String commentContent, User user, Board board) {
         this.commentContent = commentContent;
-        this.commentCreateDate = commentCreateDate; // 초기값 설정
         this.user = user;
         this.board = board;
-        this.likesCount = 0; // 기본값으로 좋아요 수를 0으로 설정
+        this.likesCount = 0;
     }
 
-    public int getLikeCount() {
-        return likesCount;
+    @PrePersist
+    protected void onCreate() {
+        this.commentCreateDate = LocalDateTime.now();
     }
 
-    public void incrementLikes() {
-        this.likesCount++;
-    }
+    public void incrementLikes() { this.likesCount++; }
+    public void decrementLikes() { this.likesCount--; }
 
-    public void decrementLikes() {
-        this.likesCount--;
-    }
 }
+


### PR DESCRIPTION
## 주요 변경 내용

- Board 엔티티의 생성일(boardCreateDate)을 @PrePersist 어노테이션을 통해 자동 세팅되도록 변경하였습니다.
- 엔티티 빌더 및 생성자에서 boardCreateDate 파라미터를 제거하여 코드의 명확성과 일관성을 높였습니다.
- 이 변경에 따라 서비스 및 컨트롤러 등 관련된 Board 생성 코드에서도 별도의 날짜 입력이 필요 없도록 수정하였습니다.
- @Data 어노테이션을 제거하고 필요한 필드만 @Setter를 사용하여 보안성을 높였습니다.

## 기대 효과

- 불필요한 파라미터 제거로 코드 가독성 및 유지보수성 향상
- JPA 표준에 맞는 엔티티 생성일 관리로 데이터 신뢰도 강화
- 협업/리뷰 시 실무 표준을 지키는 구조로 코드 품질 향상

