### PR TITLE
Refactor: BoardService, CommentService 트랜잭션 및 코드 구조 개선

### DIFF
--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Board.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Board.java
@@ -72,5 +72,11 @@ public class Board {
     public void incrementViews() {
         this.viewCount++;
     }
+    // Board, BoardImage 양쪽에서 세팅
+    public void addBoardImage(BoardImage image) {
+        this.boardImages.add(image);    // Board에서 BoardImage를 추가
+        image.setBoard(this);           // BoardImage에서도 Board 연결
+    }
+
 }
 

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/BoardImage.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/BoardImage.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -15,6 +16,7 @@ public class BoardImage {
     private Long id;
     private String url;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "BOARD_ID", nullable = false)
     private Board board;
@@ -24,4 +26,5 @@ public class BoardImage {
         this.url = url;
         this.board = board;
     }
+
 }

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/service/BoardService.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/service/BoardService.java
@@ -1,6 +1,5 @@
 package com.balgoorm.balgoorm_backend.board.service;
 
-import com.balgoorm.balgoorm_backend.board.model.dto.request.BoardImageUploadDTO;
 import com.balgoorm.balgoorm_backend.board.model.dto.request.BoardWriteRequestDTO;
 import com.balgoorm.balgoorm_backend.board.model.dto.request.BoardEditRequest;
 import com.balgoorm.balgoorm_backend.board.model.dto.response.BoardResponseDTO;
@@ -27,7 +26,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -47,68 +45,52 @@ public class BoardService {
     @Value("${file.boardImagePath}")
     private String uploadFolder;
 
-
-
+    // 게시글 조회(엔티티 반환, 내부용)
     @Transactional(readOnly = true)
     public Board getBoardById(Long boardId) {
-        return boardRepository.findById(boardId).orElse(null);
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
     }
 
+    // 게시글 상세(응답DTO로 변환)
     @Transactional(readOnly = true)
     public BoardResponseDTO searchBoard(Long boardId) {
-        Board board = boardRepository.findById(boardId).orElseThrow(() -> new IllegalArgumentException("Board not found with id: " + boardId));
-        return new BoardResponseDTO(board);
+        return new BoardResponseDTO(getBoardById(boardId));
     }
 
+    // 게시글 목록(페이징, 정렬)
     @Transactional(readOnly = true)
     public List<BoardResponseDTO> searchBoardList(int page, int pageSize, String direction, String sortBy) {
-        Pageable pageable;
-        if ("likes".equals(sortBy)) {
-            pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.fromString(direction), "likesCount"));
-        } else if ("views".equals(sortBy)) {
-            pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.fromString(direction), "views"));
-        } else {
-            pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.fromString(direction), "boardCreateDate"));
-        }
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.fromString(direction),
+                "likes".equals(sortBy) ? "likesCount" :
+                        "views".equals(sortBy) ? "viewCount" : "boardCreateDate"
+        ));
         return boardRepository.findAll(pageable)
-                .stream()
-                .map(BoardResponseDTO::new)
+                .stream().map(BoardResponseDTO::new)
                 .collect(Collectors.toList());
     }
 
-
+    // 게시글 등록
     @Transactional
-    public Long saveBoard(BoardWriteRequestDTO boardWriteRequestDTO , String userId) {
+    public Long saveBoard(BoardWriteRequestDTO dto, String userId) {
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유저 ID가 존재하지 않습니다."));
 
         Board board = Board.builder()
-                .boardTitle(boardWriteRequestDTO.getBoardTitle())
-                .boardContent(boardWriteRequestDTO.getBoardContent())
-                .boardCreateDate(LocalDateTime.now())
+                .boardTitle(dto.getBoardTitle())
+                .boardContent(dto.getBoardContent())
                 .user(user)
                 .build();
 
         boardRepository.save(board);
-
-//        if (boardImageUploadDTO.getFiles() != null && !boardImageUploadDTO.getFiles().isEmpty()) {
-//            saveBoardImages(boardImageUploadDTO.getFiles(), board);
-//        }
-
         return board.getBoardId();
     }
 
+    // 게시글 이미지 저장 (setter 최소화, 컬렉션 초기화는 엔티티에서)
     private void saveBoardImages(List<MultipartFile> files, Board board) {
-        if (board.getBoardImages() == null) {
-            board.setBoardImages(new ArrayList<>());
-        }
         for (MultipartFile file : files) {
-            UUID uuid = UUID.randomUUID();
-            String imageFileName = uuid + "_" + file.getOriginalFilename();
-
+            String imageFileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
             File destinationFile = new File(uploadFolder + File.separator + imageFileName);
-
-            log.info("파일 업로드 경로: {}", destinationFile.getAbsolutePath());
 
             try {
                 file.transferTo(destinationFile);
@@ -122,73 +104,70 @@ public class BoardService {
                     .board(board)
                     .build();
 
-            board.getBoardImages().add(image);
             boardImageRepository.save(image);
+            board.addBoardImage(image); // 양방향 연관관계 편의 메서드 활용 (엔티티에서 구현)
         }
     }
 
+    // 게시글 수정 (Dirty Checking 활용)
     @Transactional
-    public BoardResponseDTO editBoard(Long boardId, BoardEditRequest boardEditRequest, String userId) throws IOException {
-        Board board = boardRepository.findById(boardId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+    public BoardResponseDTO editBoard(Long boardId, BoardEditRequest request, String userId) {
+        Board board = getBoardById(boardId);
         if (!board.getUser().getUserId().equals(userId)) {
             throw new IllegalArgumentException("다른 사용자의 게시글은 수정할 수 없습니다.");
         }
-        board.setBoardTitle(boardEditRequest.getBoardTitle());
-        board.setBoardContent(boardEditRequest.getBoardContent());
-
-
-        boardRepository.save(board);
+        board.setBoardTitle(request.getBoardTitle());
+        board.setBoardContent(request.getBoardContent());
         return new BoardResponseDTO(board);
     }
 
-
+    // 게시글 삭제
     @Transactional
     public BoardResponseDTO deleteBoard(Long boardId, String userId) {
-        Board board = boardRepository.findById(boardId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+        Board board = getBoardById(boardId);
         if (!board.getUser().getUserId().equals(userId)) {
             throw new IllegalArgumentException("다른 사용자의 게시글은 삭제할 수 없습니다.");
         }
-        boardRepository.deleteById(boardId);
+        boardRepository.delete(board);
         return new BoardResponseDTO(board);
     }
 
+    // 게시글 좋아요
     @Transactional
     public void likeBoard(Long boardId, Long userId) {
-        Board board = boardRepository.findById(boardId).orElseThrow(() -> new IllegalArgumentException("Board not found with id: " + boardId));
-        User user = userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+        Board board = getBoardById(boardId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
 
-        if (!likesRepository.existsByUserIdAndBoardBoardId(userId, boardId)) {
-            Likes like = new Likes(user, board);
-            likesRepository.save(like);
-            board.incrementLikes();
-            boardRepository.save(board);
-        } else {
-            throw new IllegalArgumentException("User already liked this board");
+        if (likesRepository.existsByUserIdAndBoardBoardId(userId, boardId)) {
+            throw new IllegalArgumentException("이미 좋아요를 누르셨습니다.");
         }
+        Likes like = new Likes(user, board);
+        likesRepository.save(like);
+        board.incrementLikes();
     }
 
+    // 게시글 좋아요 취소
     @Transactional
     public void unlikeBoard(Long boardId, Long userId) {
         Likes like = likesRepository.findByUserIdAndBoardBoardId(userId, boardId)
                 .orElseThrow(() -> new IllegalArgumentException("Like not found for user and board"));
-        likesRepository.delete(like);
         Board board = like.getBoard();
+        likesRepository.delete(like);
         board.decrementLikes();
-        boardRepository.save(board);
     }
 
+    // 게시글 조회수 (View)
     @Transactional
     public void viewBoard(Long boardId, Long userId) {
-        Board board = boardRepository.findById(boardId).orElseThrow(() -> new IllegalArgumentException("Board not found with id: " + boardId));
-        User user = userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+        Board board = getBoardById(boardId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
 
         if (!viewRepository.existsByUserIdAndBoardBoardId(userId, boardId)) {
             View view = new View(user, board);
             viewRepository.save(view);
             board.incrementViews();
-            boardRepository.save(board);
         }
     }
 }

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/service/CommentService.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/service/CommentService.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -28,67 +27,75 @@ public class CommentService {
     private final UserRepository userRepository;
     private final LikesRepository likesRepository;
 
+    // 댓글 작성
     @Transactional
-    public CommentResponseDTO writeComment(CommentRequestDTO commentRequestDTO, Long boardId, Long userId) {
-        Board board = boardRepository.findById(boardId).orElseThrow(() -> new IllegalArgumentException("Invalid board Id"));
-        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("Invalid user Id"));
+    public CommentResponseDTO writeComment(CommentRequestDTO dto, Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
 
         Comment comment = Comment.builder()
-                .commentContent(commentRequestDTO.getCommentContent())
+                .commentContent(dto.getCommentContent())
                 .board(board)
                 .user(user)
-                .commentCreateDate(LocalDateTime.now())
                 .build();
 
         commentRepository.save(comment);
         return new CommentResponseDTO(comment);
     }
 
+    // 댓글 수정 (Dirty Checking)
     @Transactional
-    public CommentResponseDTO updateComment(CommentRequestDTO commentRequestDTO, Long commentId, Long userId) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("Invalid comment Id"));
+    public CommentResponseDTO updateComment(CommentRequestDTO dto, Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
         if (!comment.getUser().getId().equals(userId)) {
             throw new IllegalArgumentException("다른 사용자의 댓글은 수정할 수 없습니다.");
         }
-        comment.setCommentContent(commentRequestDTO.getCommentContent());
-        commentRepository.save(comment);
+        comment.setCommentContent(dto.getCommentContent());
         return new CommentResponseDTO(comment);
     }
 
+    // 댓글 삭제
     @Transactional
     public void deleteComment(Long commentId, Long userId) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("Invalid comment Id"));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
         if (!comment.getUser().getId().equals(userId)) {
             throw new IllegalArgumentException("다른 사용자의 댓글은 삭제할 수 없습니다.");
         }
         commentRepository.delete(comment);
     }
 
+    // 댓글 좋아요
     @Transactional
     public void likeComment(Long commentId, Long userId) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new IllegalArgumentException("Invalid comment Id"));
-        User user = userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + userId));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
 
-        if (!likesRepository.existsByUserIdAndCommentCommentId(userId, commentId)) {
-            Likes like = new Likes(user, comment);
-            likesRepository.save(like);
-            comment.incrementLikes(); // 좋아요 수 증가
-            commentRepository.save(comment);
-        } else {
-            throw new IllegalArgumentException("User already liked this comment");
+        if (likesRepository.existsByUserIdAndCommentCommentId(userId, commentId)) {
+            throw new IllegalArgumentException("이미 좋아요를 누르셨습니다.");
         }
+
+        Likes like = new Likes(user, comment);
+        likesRepository.save(like);
+        comment.incrementLikes();
     }
 
+    // 댓글 좋아요 취소
     @Transactional
     public void unlikeComment(Long commentId, Long userId) {
         Likes like = likesRepository.findByUserIdAndCommentCommentId(userId, commentId)
-                .orElseThrow(() -> new IllegalArgumentException("Like not found for user and comment"));
-        likesRepository.delete(like);
+                .orElseThrow(() -> new IllegalArgumentException("좋아요 정보가 없습니다."));
         Comment comment = like.getComment();
-        comment.decrementLikes(); // 좋아요 수 감소
-        commentRepository.save(comment);
+        likesRepository.delete(like);
+        comment.decrementLikes();
     }
 
+    // 게시글별 댓글 조회
     @Transactional(readOnly = true)
     public List<CommentResponseDTO> getCommentsByBoardId(Long boardId) {
         return commentRepository.findByBoardBoardId(boardId).stream()


### PR DESCRIPTION
## 주요 변경 내용

- BoardService와 CommentService  등록, 수정, 삭제, 좋아요, 조회수 기능에서 JPA Dirty Checking을 활용하여 불필요한 save() 호출을 제거하였습니다.
- setter 호출을 최소화하고 엔티티 편의 메서드를 적극 활용하는 구조로 개선하였습니다.
- Exception 메시지를 실무 표준(한글)으로 통일하였고 코드 가독성을 높였습니다.
- Transactional(readOnly = true) 적용 등 서비스 메서드별 트랜잭션 설정을 명확히 하였습니다.
- 연관관계 관리 편의 메서드(addBoardImage, setBoard 등)를 추가하여 JPA 양방향 매핑의 일관성을 높였습니다.

## 기대 효과

- JPA 표준에 맞는 엔티티 관리와 코드 품질 향상
- save() 남용 최소화로 트랜잭션 처리 및 성능 개선
- 코드 가독성, 확장성, 협업 효율성 강화
