### PR TITLE
Refactor: @Setter 전체 적용 X, 엔티티 기본 생성자 접근제어 protected로 변경 (JPA 무분별 생성 방지)

### DIFF
--- a/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
@@ -1,15 +1,12 @@
 package com.balgoorm.balgoorm_backend.user.model.entity;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "USERS")
 public class User {
 

--- a/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/user/model/entity/User.java
@@ -7,7 +7,6 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Setter
 @Getter
 @Entity
 @NoArgsConstructor


### PR DESCRIPTION
## 주요 변경 내용
- 전체 적용되어 있던 @Setter를 최소화하여 필요한 필드 개별 적용으로 수정하였습니다.
- JPA 기본 생성자에 @NoArgsConstructor(access = AccessLevel.PROTECTED)를 적용하여 외부에서 무분별하게 객체가 생성되는 것을 방지하고 데이터 무결성을 강화하였습니다.

## 기대 효과

- JPA 엔티티의 불변성 및 캡슐화 향상
- 실무 표준에 부합하는 엔티티 구조로, 코드 안전성과 유지보수성 강화
- 협업 및 코드 리뷰 시 가독성, 신뢰성 상승