### PR TITLE
Refactor: Board 관련 엔티티 기본 생성자 접근제어 protected로 변경 (JPA 무분별 생성 방지)

### DIFF
--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Board.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Board.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Board {
 
     @Id

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/BoardImage.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/BoardImage.java
@@ -1,14 +1,11 @@
 package com.balgoorm.balgoorm_backend.board.model.entity;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "boardImage")
 public class BoardImage {
     @Id

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Comment.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Comment.java
@@ -2,10 +2,7 @@ package com.balgoorm.balgoorm_backend.board.model.entity;
 
 import com.balgoorm.balgoorm_backend.user.model.entity.User;
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -13,7 +10,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Likes.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/Likes.java
@@ -2,12 +2,13 @@ package com.balgoorm.balgoorm_backend.board.model.entity;
 
 import com.balgoorm.balgoorm_backend.user.model.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Likes {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/View.java
+++ b/src/main/java/com/balgoorm/balgoorm_backend/board/model/entity/View.java
@@ -2,12 +2,13 @@ package com.balgoorm.balgoorm_backend.board.model.entity;
 
 import com.balgoorm.balgoorm_backend.user.model.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class View {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 주요 변경 내용
- JPA 기본 생성자에 @NoArgsConstructor(access = AccessLevel.PROTECTED)를 적용하여 외부에서 무분별하게 객체가 생성되는 것을 방지하고 데이터 무결성을 강화하였습니다.


## 기대 효과

- JPA 엔티티의 불변성 및 캡슐화 향상
- 실무 표준에 부합하는 엔티티 구조로, 코드 안전성과 유지보수성 강화
